### PR TITLE
Issue-118

### DIFF
--- a/addon/background.js
+++ b/addon/background.js
@@ -15,13 +15,20 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         return;
       }
       let [orgId] = cookie.value.split("!");
-      chrome.cookies.getAll({name: "sid", domain: "salesforce.com", secure: true, storeId: sender.tab.cookieStoreId}, cookies => {
-        let sessionCookie = cookies.find(c => c.value.startsWith(orgId + "!"));
-        if (!sessionCookie) {
-          sendResponse(null);
+      chrome.cookies.getAll({name: "sid", domain: "salesforce.com", secure: true, storeId: sender.tab.cookieStoreId}, sfCookies => {
+        let sfSessionCookie = sfCookies.find(c => c.value.startsWith(orgId + "!"));
+        if (!sfSessionCookie) {
+          chrome.cookies.getAll({name: "sid", domain: "cloudforce.com", secure: true, storeId: sender.tab.cookieStoreId}, cfCookies => {
+            let cfSessionCookie = cfCookies.find(c => c.value.startsWith(orgId + "!"));
+            if (!cfSessionCookie) {
+              sendResponse(null);
+              return;
+            }
+            sendResponse(cfSessionCookie.domain);
+          });
           return;
         }
-        sendResponse(sessionCookie.domain);
+        sendResponse(sfSessionCookie.domain);
       });
     });
     return true; // Tell Chrome that we want to call sendResponse asynchronously.

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -15,11 +15,17 @@
   "permissions": [
     "https://*.salesforce.com/*",
     "https://*.force.com/*",
+    "https://*.cloudforce.com/*",
     "cookies"
   ],
   "content_scripts": [
     {
-      "matches": ["https://*.salesforce.com/*", "https://*.visual.force.com/*", "https://*.lightning.force.com/*"],
+      "matches": [
+        "https://*.salesforce.com/*",
+        "https://*.visual.force.com/*",
+        "https://*.lightning.force.com/*",
+        "https://*.cloudforce.com/*"
+      ],
       "all_frames": true,
       "css": [
         "button.css",

--- a/addon/popup.js
+++ b/addon/popup.js
@@ -707,7 +707,7 @@ function getRecordId(href) {
   // Find record ID from URL
   let searchParams = new URLSearchParams(url.search.substring(1));
   // Salesforce Classic and Console
-  if (url.hostname.endsWith(".salesforce.com")) {
+  if (url.hostname.endsWith(".salesforce.com") || url.hostname.endsWith(".cloudforce.com")) {
     let match = url.pathname.match(/\/([a-zA-Z0-9]{3}|[a-zA-Z0-9]{15}|[a-zA-Z0-9]{18})(?:\/|$)/);
     if (match) {
       let res = match[1];


### PR DESCRIPTION
#### Change Summary
- Added support for cloudforce.com

#### Notes
- This is a quick fix to enable support for cloudforce.com domains.   When doing so, I realize there is an opportunity to reduce some nesting in the background message handler.  This PR will work for the use case, a follow on could address some of the tech debt there.

#### References:
- https://github.com/sorenkrabbe/Chrome-Salesforce-inspector/issues/118

